### PR TITLE
Add setting to enable/disable whitelist:

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -7,6 +7,9 @@ local world_path = minetest.get_worldpath()
 local admin = minetest.setting_get("name")
 local whitelist = {}
 
+-- Enabled by default
+local enabled = minetest.setting_getbool("whitelist.enable") ~= false
+
 local function load_whitelist()
 	local file, err = io.open(world_path.."/whitelist.txt", "r")
 	if err then
@@ -31,12 +34,14 @@ end
 
 load_whitelist()
 
-minetest.register_on_prejoinplayer(function(name, ip)
-	if name == "singleplayer" or name == admin or whitelist[name] then
-		return
-	end
-	return "This server is whitelisted and you are not on the whitelist."
-end)
+if enabled then
+	minetest.register_on_prejoinplayer(function(name, ip)
+		if name == "singleplayer" or name == admin or whitelist[name] then
+			return
+		end
+		return "This server is whitelisted and you are not on the whitelist."
+	end)
+end
 
 minetest.register_chatcommand("whitelist", {
 	params = "{add|remove} <nick>",

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,3 @@
+
+# Enables/Disables whitelist feature.
+whitelist.enable (Enable whitelist) bool true


### PR DESCRIPTION
You already said in the forum to just enable/disable the mod at the server level. But I personally prefer to use a configuration setting. That way, I can add the mod to my sub-game & server owners can just change the setting in ***minetest.conf***.

This branch adds the setting ***whitelist.enable*** (which is set to ***false*** by default). ***register_on_prejoinplayer*** is only called if this setting is ***true***.

I understand if you don't want to merge though.